### PR TITLE
update gemspec to latest specification

### DIFF
--- a/dbf.gemspec
+++ b/dbf.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = 'A small fast library for reading dBase, xBase, Clipper and FoxPro database files.'
   
   s.executables = ['dbf']
-  s.default_executable = 'dbf'
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'CHANGELOG.md', 'MIT-LICENSE']
   s.files = Dir['[A-Z]*', '{bin,docs,lib,spec}/**/*']


### PR DESCRIPTION
Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2011-10-01.
