### PR TITLE
Update i18n and activesupport gem versions.

### DIFF
--- a/dbf.gemspec
+++ b/dbf.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.required_rubygems_version = '>= 1.3.0'
-  s.add_dependency 'activesupport', '~> 3.0.0'
+  s.add_dependency 'activesupport', '~> 3.1.0'
   s.add_dependency 'i18n', '~> 0.6.0'
   s.add_dependency 'fastercsv', '1.5.4'
   s.add_development_dependency 'rspec', '2.5.0'


### PR DESCRIPTION
Rails 3.1 was just released, and it depends on later versions than are compatible with dbf.  I have updated them with two separate commits.  The unit tests continue to pass.  Thanks.
