### PR TITLE
fix compatibility when MRI version greater than 1.9.1

### DIFF
--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module DBF
 
   # DBF::Table is the primary interface to a single DBF file and provides
@@ -214,7 +216,7 @@ module DBF
     end
 
     def self.encodings
-      @encodings ||= YAML.load_file(File.expand_path("../encodings.yml", __FILE__))
+      @encodings ||= YAML.load File.read(File.expand_path("../encodings.yml", __FILE__))
     end
   end
 


### PR DESCRIPTION
- YAML.load_file last exists at MRI(v1_9_1_378).
- RSpec require yaml lib at rspec-core gem, thus need do a explicit
  requirement here.
