### PR TITLE
update specs to work with 1.8.6 and update supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ database files
 
 ## Compatibility
 
-DBF is tested to work with MRI Ruby 1.8.6, 1.8.7, 1.9.2, 1.9.3 and Jruby 1.6.2
+DBF is tested to work with the following versions of ruby:
+
+* MRI Ruby 1.8.6, 1.8.7, 1.9.1, 1.9.2 and 1.9.3
+* JRuby 1.6.2, 1.6.3, 1.6.4, and 1.6.5
+* REE 1.8.7
 
 ## Installation
   

--- a/spec/dbf/column_spec.rb
+++ b/spec/dbf/column_spec.rb
@@ -40,7 +40,7 @@ describe DBF::Column do
         it 'casts value to Fixnum' do
           value = '135'
           column = DBF::Column.new "ColumnName", "N", 3, 0, "30"
-          column.type_cast(value).should be_a Fixnum
+          column.type_cast(value).should be_a(Fixnum)
           column.type_cast(value).should == 135
         end
       end
@@ -49,7 +49,7 @@ describe DBF::Column do
         it 'casts value to Float' do
           value = '13.5'
           column = DBF::Column.new "ColumnName", "N", 2, 1, "30"
-          column.type_cast(value).should be_a Float
+          column.type_cast(value).should be_a(Float)
           column.type_cast(value).should == 13.5
         end
       end
@@ -59,7 +59,7 @@ describe DBF::Column do
       it 'casts value to Float' do
         value = '135'
         column = DBF::Column.new "ColumnName", "F", 3, 0, "30"
-        column.type_cast(value).should be_a Float
+        column.type_cast(value).should be_a(Float)
         column.type_cast(value).should == 135.0
       end
     end
@@ -123,7 +123,7 @@ describe DBF::Column do
     context 'with type M (memo)' do
       it "casts to string" do
         column = DBF::Column.new "ColumnName", "M", 3, 0, "30"
-        column.type_cast('abc').should be_a String
+        column.type_cast('abc').should be_a(String)
       end
     end
   end

--- a/spec/dbf/file_formats_spec.rb
+++ b/spec/dbf/file_formats_spec.rb
@@ -13,7 +13,7 @@ shared_examples_for 'DBF' do
   end
   
   specify "record count should be the same as reported in the header" do
-    @table.count.should == @table.record_count
+    @table.entries.size.should == @table.record_count
   end
   
   specify "column names should not be blank" do

--- a/spec/dbf/table_spec.rb
+++ b/spec/dbf/table_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe DBF::Table do  
   specify 'foxpro versions' do
-    DBF::Table::FOXPRO_VERSIONS.keys.should == %w(30 31 f5 fb)
+    DBF::Table::FOXPRO_VERSIONS.keys.sort.should == %w(30 31 f5 fb).sort
   end
 
   describe '#initialize' do
@@ -167,7 +167,7 @@ describe DBF::Table do
       end
 
       it "should return the first record if options are empty" do
-        @table.find(:first).should == @table.first
+        @table.find(:first).should == @table.record(0)
       end
 
       it "should return the first matching record when used with options" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ require 'rspec'
 
 DB_PATH = File.dirname(__FILE__) + '/fixtures' unless defined?(DB_PATH)
 
+if RUBY_VERSION == "1.8.6"
+  warn 'ruby-1.8.6: defining Array#reduce as alias of Array#inject'
+  class Array
+    alias_method :reduce, :inject
+  end
+end
+
 RSpec.configure do |config|
   
 end


### PR DESCRIPTION
I was validating my code (the in-memory-dbf changes) against all the listed versions and came across the fact that several specs fail against 1.8.6.

It seems as though the specs for `DBF::Table` assume `Enumerable#count` exists which isn't the case for 1.8.6, it was introduced in 1.8.7.  This impacts every usage of the following spec:

``` ruby
# file_format_spec.rb:15
specify "record count should be the same as reported in the header" do
  @table.count.should == @table.record_count
end
```

The same is true for `Enumerable#first`.

``` ruby
# table_spec.rb:169
it "should return the first record if options are empty" do
  @table.find(:first).should == @table.first
end
```

The following spec was also failing because the sort order of `Hash#keys` doesn't match the defined list for 1.8.6:

``` ruby
# table_spec.rb:4
specify 'foxpro versions' do
  DBF::Table::FOXPRO_VERSIONS.keys.should == %w(30 31 f5 fb)
end
```

Since the code itself seems to work (per the specs anyway) once the specs themselves are updated to work with 1.8.6 this pull request simply does exactly that.  I've also gone ahead and tested against MRI 1.9.1, REE 1.8.7 and JRuby 1.6.3-1.6.5 and updated the tested version list to reflect the same.

Finally, as of rspec-core 2.7.1, a call to `Enumerable#reduce` was added within rspec itself that causes all the specs to fail on 1.8.6.  To fix this I've added a conditional monkey-patch in spec_helper.rb to alias `inject` as `reduce`.  There's fix in rspec-core master to resolve this as of the next release, at which point this patch can be removed.
