### PR TITLE
Fix usage with Rails 3.1

### DIFF
--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -227,7 +227,7 @@ module DBF
     end
     
     def column_count #nodoc
-      @column_count ||= (@header_length - DBF_HEADER_SIZE + 1) / DBF_HEADER_SIZE
+      @column_count ||= ((@header_length - DBF_HEADER_SIZE + 1) / DBF_HEADER_SIZE).to_i
     end
 
     def open_data(data)


### PR DESCRIPTION
This fixes environments like Rails 3.1 where integer division is
redefined to result in a Rational, which then breaks because
Rational#times is not defined.
