### PR TITLE
Possible fix for Issue #37

### DIFF
--- a/lib/dbf/record.rb
+++ b/lib/dbf/record.rb
@@ -51,11 +51,9 @@ module DBF
     def define_accessors #nodoc
       @column_names.each do |name|
         next if respond_to? name
-        self.class.class_eval <<-END
-          def #{name}
-            @#{name} ||= attributes['#{name}']
-          end
-        END
+        self.class.send(:define_method, name) do
+          attributes[name]
+        end
       end
     end
     


### PR DESCRIPTION
It no longer caches properties in an @ivar, but I don't think that's much of an issue. Fields with invalid characters can only be accessed via the accessor method using 'send', but that's better than a syntax error.

e.g. the column 'foo bar' can only be called by doing: x.send('foo bar')
