### PR TITLE
Activerecord and decimal fix

### DIFF
--- a/lib/dbf/column/base.rb
+++ b/lib/dbf/column/base.rb
@@ -48,6 +48,11 @@ module DBF
         "\"#{underscored_name}\", #{schema_data_type}\n"
       end
 
+      def index_definition(table)
+        index = (underscored_name().end_with? "id")
+        index ? "add_index \"#{table}\", [\"#{underscored_name}\"]\n" : ""
+      end
+
       def underscored_name
         @underscored_name ||= Util.underscore(name)
       end

--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -136,7 +136,11 @@ module DBF
       columns.each do |column|
         s << "    t.column #{column.schema_definition}"
       end
-      s << "  end\nend"
+      s << "  end\n"
+      columns.each do |column|
+        s << "  #{column.index_definition(File.basename(@data.path, ".*"))}"
+      end
+      s << "\nend"
       s
     end
 


### PR DESCRIPTION
this handle the case when a column had a type of 'Y' (decimal)
When generating activerecord definitions it attempts to add indexes by assuming a column that ends with 'id' should have an index.
