### PR TITLE
fix transncode of memo columns.

### DIFF
--- a/lib/dbf/record.rb
+++ b/lib/dbf/record.rb
@@ -58,11 +58,12 @@ module DBF
     end
     
     def init_attribute(column) #nodoc
-      if column.memo?
+      value = if column.memo?
         @memo.get get_memo_start_block(column)
       else
-        column.type_cast unpack_data(column)
+        unpack_data(column)
       end
+      column.type_cast value
     end
    
     def get_memo_start_block(column) #nodoc


### PR DESCRIPTION
I was having problems with the encoding of memo fields, and found that there were a bug so they are not being encoded.

I'm not sure how to do the specs for this (because there are no encoding spec). I'll try to add them later.

Itried to keep the code simple, but correct me if you see a mistake.

Thank you for this gem, is realy usefull!
