### PR TITLE
set encoding if table encoding is nil

### DIFF
--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -23,7 +23,7 @@ module DBF
       "f5" => "FoxPro with memo file",
       "fb" => "FoxPro without memo file"
     }
-    
+
     FOXPRO_VERSIONS = {
       "30" => "Visual FoxPro",
       "31" => "Visual FoxPro with AutoIncrement field",
@@ -59,10 +59,10 @@ module DBF
     def initialize(data, memo = nil, encoding = nil)
       @data = open_data(data)
       get_header_info
-      @encoding = encoding if encoding && @encoding
+      @encoding = encoding || @encoding
       @memo = open_memo(data, memo)
     end
-    
+
     # @return [TrueClass, FalseClass]
     def has_memo_file?
       !!@memo
@@ -75,7 +75,7 @@ module DBF
       @data.close
       @memo && @memo.close
     end
-    
+
     # @return [TrueClass, FalseClass]
     def closed?
       if @memo
@@ -84,7 +84,7 @@ module DBF
         @data.closed?
       end
     end
-    
+
     # @return String
     def filename
       File.basename @data.path
@@ -213,24 +213,24 @@ module DBF
         columns
       end
     end
-    
+
     def supports_encoding?
       String.new.respond_to?(:encoding)
     end
-    
+
     def supports_iconv?
       require 'iconv'
       true
     rescue
       false
     end
-    
+
     def foxpro?
       FOXPRO_VERSIONS.keys.include? @version
     end
 
     private
-    
+
     def column_class #nodoc
       @column_class ||= if foxpro?
         Column::Foxpro
@@ -238,7 +238,7 @@ module DBF
         Column::Dbase
       end
     end
-    
+
     def memo_class #nodoc
       @memo_class ||= if foxpro?
         Memo::Foxpro
@@ -250,7 +250,7 @@ module DBF
         end
       end
     end
-    
+
     def column_count #nodoc
       @column_count ||= ((@header_length - DBF_HEADER_SIZE + 1) / DBF_HEADER_SIZE).to_i
     end
@@ -296,7 +296,7 @@ module DBF
       @version, @record_count, @header_length, @record_length, @encoding_key = read_header
       @encoding = ENCODINGS[@encoding_key] if supports_encoding? || supports_iconv?
     end
-    
+
     def read_header #nodoc
       @data.read(DBF_HEADER_SIZE).unpack("H2 x3 V v2 x17H2")
     end


### PR DESCRIPTION
That is fix in logic for overriding encoding if table's encoding is nil
