### PR TITLE
Allow zero length column

### DIFF
--- a/lib/dbf/column/base.rb
+++ b/lib/dbf/column/base.rb
@@ -24,8 +24,8 @@ module DBF
         @version = table.version
         @encoding = table.encoding
 
-        unless length > 0
-          raise LengthError, "field length must be greater than 0"
+        unless length >= 0
+          raise LengthError, "field length must be greater than or equal 0"
         end
 
         if @name.empty?

--- a/spec/dbf/column_spec.rb
+++ b/spec/dbf/column_spec.rb
@@ -24,10 +24,9 @@ describe DBF::Column::Dbase do
       expect(column.decimal).to eq 0
     end
 
-    describe 'with length of 0' do
-      it 'raises DBF::Column::LengthError' do
-        expect { DBF::Column::Dbase.new table, "ColumnName", "N", 0, 0 }.to raise_error(DBF::Column::LengthError)
-      end
+    it 'accepts length of 0' do
+      column = DBF::Column::Dbase.new table, "ColumnName", "N", 0, 0
+      expect(column.length).to eq 0
     end
 
     describe 'with length less than 0' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ end
 require 'dbf'
 require 'yaml'
 require 'rspec'
+require 'fileutils'
 
 Encoding.default_external = "UTF-8" if defined?(Encoding)
 


### PR DESCRIPTION
Hi, we have DBF file with column that have zero column length and no data in it. I have altered DBF::Column#initialize to accept zero length columns. All tests passes.