### PR TITLE
Makes type casting consistent with schema.

### DIFF
--- a/lib/dbf/column/base.rb
+++ b/lib/dbf/column/base.rb
@@ -74,7 +74,7 @@ module DBF
       private
 
       def type_cast_methods # nodoc
-        {
+        m = {
           'N' => :unpack_number,
           'I' => :unpack_unsigned_long,
           'F' => :unpack_float,
@@ -84,6 +84,10 @@ module DBF
           'L' => :boolean,
           'M' => :decode_memo
         }
+        if DBF::Table::FOXPRO_VERSIONS.keys.include?(@version)
+          m['B'] = :unpack_double
+        end
+        m
       end
 
       def decode_date(value) # nodoc
@@ -119,6 +123,10 @@ module DBF
 
       def unpack_float(value) # nodoc
         value.to_f
+      end
+
+      def unpack_double(value) # nodoc
+        value.unpack('E')[0]
       end
 
       def boolean(value) # nodoc
@@ -160,7 +168,7 @@ module DBF
           ':text'
         when 'B'
           if DBF::Table::FOXPRO_VERSIONS.keys.include?(@version)
-            decimal > 0 ? ':float' : ':integer'
+            ':float'
           else
             ':text'
           end

--- a/spec/dbf/column_spec.rb
+++ b/spec/dbf/column_spec.rb
@@ -86,6 +86,22 @@ describe DBF::Column::Dbase do
       end
     end
 
+    context "with type B (binary)" do
+      context "with Foxpro dbf" do
+        it 'casts to float' do
+          column = DBF::Column::Dbase.new table, "ColumnName", "B", 1, 2
+          expect(column.type_cast("\xEC\x51\xB8\x1E\x85\x6B\x31\x40")).to be_a(Float)
+          expect(column.type_cast("\xEC\x51\xB8\x1E\x85\x6B\x31\x40")).to eq 17.42
+        end
+
+        it 'stores original precision' do
+          column = DBF::Column::Dbase.new table, "ColumnName", "B", 1, 0
+          expect(column.type_cast("\xEC\x51\xB8\x1E\x85\x6B\x31\x40")).to be_a(Float)
+          expect(column.type_cast("\xEC\x51\xB8\x1E\x85\x6B\x31\x40")).to eq 17.42
+        end
+      end
+    end
+
     context 'with type I (integer)' do
       context 'and 0 length' do
         it 'returns nil' do
@@ -236,18 +252,9 @@ describe DBF::Column::Dbase do
 
     context "with type B (binary)" do
       context "with Foxpro dbf" do
-        context "when decimal is greater than 0" do
-          it "outputs an float column" do
-            column = DBF::Column::Dbase.new table, "ColumnName", "B", 1, 2
-            expect(column.schema_definition).to eq "\"column_name\", :float\n"
-          end
-        end
-
-        context "when decimal is 0" do
-          it "outputs an integer column" do
-            column = DBF::Column::Dbase.new table, "ColumnName", "B", 1, 0
-            expect(column.schema_definition).to eq "\"column_name\", :integer\n"
-          end
+        it "outputs a float column" do
+          column = DBF::Column::Dbase.new table, "ColumnName", "B", 1, 2
+          expect(column.schema_definition).to eq "\"column_name\", :float\n"
         end
       end
     end


### PR DESCRIPTION
For FoxPro databases the returned type differed from the reported schema, which was confusing.