### PR TITLE
Read currency as 64bit numbers.

### DIFF
--- a/lib/dbf/column/base.rb
+++ b/lib/dbf/column/base.rb
@@ -111,7 +111,7 @@ module DBF
       end
 
       def unpack_currency(value) # nodoc
-        (unpack_signed_long(value) / 10_000.0).to_f
+        (value.unpack('q<')[0] / 10_000.0).to_f
       end
 
       def unpack_signed_long(value) # nodoc

--- a/spec/dbf/column_spec.rb
+++ b/spec/dbf/column_spec.rb
@@ -273,6 +273,11 @@ describe DBF::Column::Dbase do
       expect(column.type_cast("\xFC\xF0\xF0\xFE\xFF\xFF\xFF\xFF")).to eq -1776.41
     end
 
+    it 'supports 64bit negative currency' do
+      expect(column.type_cast("pN'9\xFF\xFF\xFF\xFF")).to be_a(Float)
+      expect(column.type_cast("pN'9\xFF\xFF\xFF\xFF")).to eq -333609.0
+    end
+
     context 'and 0 length' do
       it 'returns nil' do
         column = DBF::Column::Dbase.new table, "ColumnName", "Y", 0, 0


### PR DESCRIPTION
Currency was read as 32bit number, which discarded half the number.