### PR TITLE
Performance improvements.

### DIFF
--- a/lib/dbf/column.rb
+++ b/lib/dbf/column.rb
@@ -46,11 +46,7 @@ module DBF
     # @param [String] value
     # @return [Fixnum, Float, Date, DateTime, Boolean, String]
     def type_cast(value)
-      return nil if length == 0
-
-      klass = TYPE_CAST_CLASS[type.to_sym]
-      cast_value = klass.new(value, decimal).type_cast
-      binary? ? cast_value : encode(cast_value)
+      type_cast_class.type_cast(value)
     end
 
     # Returns true if the column is a memo
@@ -97,6 +93,15 @@ module DBF
     end
 
     private
+
+    def type_cast_class # nodoc
+      @type_cast_class ||=
+        if @length == 0
+          ColumnType::Nil
+        else
+          TYPE_CAST_CLASS[type.to_sym]
+        end.new(@decimal, @encoding)
+    end
 
     def encode(value, strip_output = false) # nodoc
       return value if !value.respond_to?(:encoding)

--- a/lib/dbf/column_type.rb
+++ b/lib/dbf/column_type.rb
@@ -1,52 +1,58 @@
 module DBF
   module ColumnType
     class Base
-      attr_reader :value, :decimal
+      attr_reader :decimal, :encoding
 
-      def initialize(value, decimal)
-        @value = value
+      def initialize(decimal, encoding)
         @decimal = decimal
+        @encoding = encoding
+      end
+    end
+
+    class Nil < Base
+      def type_cast(value)
+        nil
       end
     end
 
     class Number < Base
-      def type_cast
-        decimal.zero? ? value.to_i : value.to_f
+      def type_cast(value)
+        @decimal.zero? ? value.to_i : value.to_f
       end
     end
 
     class Currency < Base
-      def type_cast
+      def type_cast(value)
         (value.unpack('q<')[0] / 10_000.0).to_f
       end
     end
 
     class SignedLong < Base
-      def type_cast
+      def type_cast(value)
         value.unpack('l<')[0]
       end
     end
 
     class Float < Base
-      def type_cast
+      def type_cast(value)
         value.to_f
       end
     end
 
     class Double < Base
-      def type_cast
+      def type_cast(value)
         value.unpack('E')[0]
       end
     end
 
     class Boolean < Base
-      def type_cast
+      def type_cast(value)
         value.strip =~ /^(y|t)$/i ? true : false
       end
     end
 
     class Date < Base
-      def type_cast
+      def type_cast(value)
         v = value.tr(' ', '0')
         v !~ /\S/ ? nil : ::Date.parse(v)
       rescue
@@ -55,7 +61,7 @@ module DBF
     end
 
     class DateTime < Base
-      def type_cast
+      def type_cast(value)
         days, msecs = value.unpack('l2')
         secs = (msecs / 1000).to_i
         ::DateTime.jd(days, (secs / 3600).to_i, (secs / 60).to_i % 60, secs % 60)
@@ -65,21 +71,37 @@ module DBF
     end
 
     class Memo < Base
-      def type_cast
-        value
+      ENCODING_ARGS = [
+        Encoding.default_external,
+        {undef: :replace, invalid: :replace}
+      ]
+
+      def type_cast(value)
+        if encoding and not value.nil?
+          value.force_encoding(@encoding).encode(*ENCODING_ARGS)
+        else
+          value
+        end
       end
     end
 
     class General < Base
-      def type_cast
+      def type_cast(value)
         value
       end
     end
 
     class String < Base
-      def type_cast
-        value.strip
+      ENCODING_ARGS = [
+        Encoding.default_external,
+        {undef: :replace, invalid: :replace}
+      ]
+
+      def type_cast(value)
+        value = value.strip
+        @encoding ? value.force_encoding(@encoding).encode(*ENCODING_ARGS) : value
       end
     end
+
   end
 end

--- a/lib/dbf/record.rb
+++ b/lib/dbf/record.rb
@@ -90,7 +90,7 @@ module DBF
     end
 
     def init_attribute(column) # nodoc
-      value = column.memo? ? memo(column) : unpack_data(column)
+      value = column.memo? ? memo(column) : get_data(column)
       column.type_cast(value)
     end
 
@@ -105,13 +105,15 @@ module DBF
     end
 
     def memo_start_block(column) # nodoc
-      format = 'V' if %w(30 31).include?(@version)
-      unpack_data(column, format).to_i
+      data = get_data(column)
+      if %w(30 31).include?(@version)
+        data = data.unpack('V').first
+      end
+      data.to_i
     end
 
-    def unpack_data(column, format = nil) # nodoc
-      format ||= "a#{column.length}"
-      @data.read(column.length).unpack(format).first
+    def get_data(column) # nodoc
+      @data.read(column.length)
     end
   end
 end


### PR DESCRIPTION
When reading large DBF files (I have some with 200000 rows), it's important to do as few operations for reading each row. With these fixes, loading my large tables takes only 1/2 to 2/3 of the time it took without.