### PR TITLE
Added support for Sequel migrations

### DIFF
--- a/bin/dbf
+++ b/bin/dbf
@@ -3,22 +3,35 @@
 require 'dbf'
 require 'optparse'
 
-params = ARGV.getopts('h', 's', 'a', 'c')
+params = ARGV.getopts('h', 's', 'a', 'c', 'r', 'v')
 
-if params['h'] then
-  puts "usage: #{File.basename(__FILE__)} [-h|-s|-a|-c] filename"
+if params['v'] then
+  require 'dbf/version'
+  puts "dbf version: #{DBF::VERSION}"
+
+elsif params['h'] then
+  puts "usage: #{File.basename(__FILE__)} [-h|-s|-a|-c|-r] filename"
   puts "  -h = print this message"
+  puts "  -v = outputs the DBF gem version"
   puts "  -s = print summary information"
   puts "  -a = create an ActiveRecord::Schema"
+  puts "  -r = create a Sequel Migration"
   puts "  -c = create a csv file"
 else
+  
   filename = ARGV.shift
   abort "You must supply a filename on the command line" unless filename
 
   # create an ActiveRecord::Schema
   if params['a']
     table = DBF::Table.new filename
-    puts table.schema
+    puts table.schema(:activerecord)
+  end
+
+  # create an Sequel::Migration
+  if params['r']
+    table = DBF::Table.new filename
+    puts table.schema(:sequel)
   end
 
   if params['s']

--- a/lib/dbf/column.rb
+++ b/lib/dbf/column.rb
@@ -62,6 +62,13 @@ module DBF
     def schema_definition
       "\"#{underscored_name}\", #{schema_data_type}\n"
     end
+    
+    # Sequel Schema definition
+    #
+    # @return [String]
+    def sequel_schema_definition
+      ":#{underscored_name}, #{schema_data_type(:sequel)}\n"
+    end
 
     # Underscored name
     #
@@ -112,14 +119,14 @@ module DBF
       ]
     end
 
-    def schema_data_type # nodoc
+    def schema_data_type(format = :activerecord) # nodoc
       case type
       when 'N', 'F'
         decimal > 0 ? ':float' : ':integer'
       when 'I'
         ':integer'
       when 'Y'
-        ':decimal, :precision => 15, :scale => 4'
+        ':decimal, precision: 15, scale: 4'
       when 'D'
         ':date'
       when 'T'
@@ -135,7 +142,11 @@ module DBF
           ':text'
         end
       else
-        ":string, :limit => #{length}"
+        if format == :sequel
+          ":varchar, size: #{length}"
+        else
+          ":string, limit: #{length}"
+        end
       end
     end
 

--- a/spec/dbf/table_spec.rb
+++ b/spec/dbf/table_spec.rb
@@ -56,6 +56,57 @@ RSpec.describe DBF::Table do
     end
   end
 
+  describe '#sequel_schema' do
+    it 'should return a valid Sequel migration by default' do
+      expect(table.sequel_schema).to eq <<-SCHEMA
+Sequel.migration do
+  change do
+     create_table(:dbase_83) do
+      column :id, :integer
+      column :catcount, :integer
+      column :agrpcount, :integer
+      column :pgrpcount, :integer
+      column :order, :integer
+      column :code, :varchar, :size => 50
+      column :name, :varchar, :size => 100
+      column :thumbnail, :varchar, :size => 254
+      column :image, :varchar, :size => 254
+      column :price, :float
+      column :cost, :float
+      column :desc, :text
+      column :weight, :float
+      column :taxable, :boolean
+      column :active, :boolean
+    end
+  end
+end
+SCHEMA
+    end
+    
+    it 'should return a limited Sequel migration when passed true' do
+      expect(table.sequel_schema(true)).to eq <<-SCHEMA
+    create_table(:dbase_83) do
+      column :id, :integer
+      column :catcount, :integer
+      column :agrpcount, :integer
+      column :pgrpcount, :integer
+      column :order, :integer
+      column :code, :varchar, :size => 50
+      column :name, :varchar, :size => 100
+      column :thumbnail, :varchar, :size => 254
+      column :image, :varchar, :size => 254
+      column :price, :float
+      column :cost, :float
+      column :desc, :text
+      column :weight, :float
+      column :taxable, :boolean
+      column :active, :boolean
+    end
+SCHEMA
+    end
+    
+  end
+
   describe '#json_schema' do
     it 'is valid JSON' do
       expect { JSON.parse(table.json_schema) }.to_not raise_error


### PR DESCRIPTION
Hi, 

I created a quick hack to add [Sequel](https://github.com/jeremyevans/sequel) Migration support.

I hope you would be willing to merge this into master

Thanks for your time and attention.

The commit includes the following changes:
- added Sequel schema output & tests.
- amended :activerecord_schema & :json_schema methods to accept a param in order to handle required sequel schema functionality.
- amended :schema_data_type method to handle Sequel features.
- added :sequel_schema_definition.
- added -r option to CLI to generate Sequel Migration.
- added -v option to CLI to output DBF version.
- updated README.md with new functionality.