### PR TITLE
Allow for overriding table name during schema dumps

### DIFF
--- a/lib/dbf/schema.rb
+++ b/lib/dbf/schema.rb
@@ -34,7 +34,7 @@ module DBF
 
     def activerecord_schema(_table_only = false)
       s = "ActiveRecord::Schema.define do\n"
-      s << "  create_table \"#{File.basename(filename, '.*')}\" do |t|\n"
+      s << "  create_table \"#{name}\" do |t|\n"
       columns.each do |column|
         s << "    t.column #{column.schema_definition}"
       end
@@ -46,7 +46,7 @@ module DBF
       s = ''
       s << "Sequel.migration do\n" unless table_only
       s << "  change do\n " unless table_only
-      s << "    create_table(:#{File.basename(filename, '.*')}) do\n"
+      s << "    create_table(:#{name}) do\n"
       columns.each do |column|
         s << "      column #{column.sequel_schema_definition}"
       end

--- a/lib/dbf/schema.rb
+++ b/lib/dbf/schema.rb
@@ -34,7 +34,7 @@ module DBF
 
     def activerecord_schema(_table_only = false)
       s = "ActiveRecord::Schema.define do\n"
-      s << "  create_table \"#{File.basename(@data.path, '.*')}\" do |t|\n"
+      s << "  create_table \"#{File.basename(filename, '.*')}\" do |t|\n"
       columns.each do |column|
         s << "    t.column #{column.schema_definition}"
       end
@@ -46,7 +46,7 @@ module DBF
       s = ''
       s << "Sequel.migration do\n" unless table_only
       s << "  change do\n " unless table_only
-      s << "    create_table(:#{File.basename(@data.path, '.*')}) do\n"
+      s << "    create_table(:#{File.basename(filename, '.*')}) do\n"
       columns.each do |column|
         s << "      column #{column.sequel_schema_definition}"
       end

--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -39,6 +39,7 @@ module DBF
 
     attr_reader :header
     attr_accessor :encoding
+    attr_writer :name
 
     # Opens a DBF::Table
     # Examples:
@@ -96,7 +97,12 @@ module DBF
 
     # @return String
     def filename
-      File.basename @data.path
+      File.basename @data.path if @data.respond_to?(:path)
+    end
+
+    # @return String
+    def name
+      @name ||= filename && File.basename(filename, ".*")
     end
 
     # Calls block once for each record in the table. The record may be nil

--- a/spec/dbf/table_spec.rb
+++ b/spec/dbf/table_spec.rb
@@ -248,6 +248,17 @@ SCHEMA
     end
   end
 
+  describe '#name' do
+    it 'defaults to the filename less extension' do
+      expect(table.name).to eq 'dbase_83'
+    end
+
+    it 'is mutable' do
+      table.name = 'database_83'
+      expect(table.name).to eq 'database_83'
+    end
+  end
+
   describe '#has_memo_file?' do
     describe 'without a memo file' do
       let(:table) { DBF::Table.new fixture('dbase_03.dbf') }


### PR DESCRIPTION
Two relevant commits, in case you only want to cherry-pick the first.

1. Reuse `Table#filename` instead of `@data` instance variable in
DBF::Schema
2. Add `Table#name`

The first just reuses the existing `#filename` method instead of relying
on the underlying data stream.

The second adds a new `#name` accessor which makes for easier overriding
of a schema's table name, especially if the underlying data stream isn't
file based.