### PR TITLE
set default external encoding to UTF-8

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ begin
 rescue LoadError
 end
 
+Encoding.default_external = "UTF-8"
+
 require 'dbf'
 require 'yaml'
 require 'rspec'


### PR DESCRIPTION
This is needed to run the tests on environment where the local is not unicode (like LANG=C, e.g. on Debian building environments)