### PR TITLE
Include correct constant

### DIFF
--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -6,7 +6,7 @@ module DBF
   # methods for enumerating and searching the records.
   class Table
     include Enumerable
-    include Schema
+    include ::DBF::Schema
 
     DBF_HEADER_SIZE = 32
 


### PR DESCRIPTION
With rails 5 I've run into an "uninitialized constant DBF::Table::Schema"-error. I've created this Quickfix in order to solve the issue. If I just overlooked something, feel free to just discard this PR.

Thank you for your work on this gem! 