### PR TITLE
fix incorrect columns list when StringIO and encoding set

### DIFF
--- a/lib/dbf/table.rb
+++ b/lib/dbf/table.rb
@@ -209,14 +209,16 @@ module DBF
     private
 
     def build_columns # :nodoc:
-      @data.seek(DBF_HEADER_SIZE)
-      columns = []
-      until end_of_record?
-        column_data = @data.read(DBF_HEADER_SIZE)
-        name, type, length, decimal = column_data.unpack('a10 x a x4 C2')
-        columns << Column.new(self, name, type, length, decimal)
+      safe_seek do
+        @data.seek(DBF_HEADER_SIZE)
+        columns = []
+        until end_of_record?
+          column_data = @data.read(DBF_HEADER_SIZE)
+          name, type, length, decimal = column_data.unpack('a10 x a x4 C2')
+          columns << Column.new(self, name, type, length, decimal)
+        end
+        columns
       end
-      columns
     end
 
     def deleted_record? # :nodoc:
@@ -225,10 +227,9 @@ module DBF
     end
 
     def end_of_record? # :nodoc:
-      original_pos = @data.pos
-      byte = @data.read(1)
-      @data.seek(original_pos)
-      byte.ord == 13
+      safe_seek do
+        @data.read(1).ord == 13
+      end
     end
 
     def find_all(options) # :nodoc:
@@ -249,7 +250,10 @@ module DBF
     end
 
     def header # :nodoc:
-      @header ||= Header.new(@data.read DBF_HEADER_SIZE)
+      @header ||= safe_seek do
+        @data.seek(0)
+        Header.new(@data.read DBF_HEADER_SIZE)
+      end
     end
 
     def memo_class # :nodoc:
@@ -282,6 +286,11 @@ module DBF
         files = Dir.glob(memo_search_path(data))
         files.any? ? memo_class.open(files.first, version) : nil
       end
+    end
+
+    def safe_seek
+      original_pos = @data.pos
+      yield.tap{ @data.seek(original_pos) }
     end
 
     def seek(offset) # :nodoc:

--- a/spec/dbf/table_spec.rb
+++ b/spec/dbf/table_spec.rb
@@ -295,8 +295,19 @@ RSpec.describe DBF::Table do
       %w[ID CATCOUNT AGRPCOUNT PGRPCOUNT ORDER CODE NAME THUMBNAIL IMAGE PRICE COST DESC WEIGHT TAXABLE ACTIVE]
     end
 
-    it 'is an array of all column names' do
-      expect(table.column_names).to eq column_names
+    describe 'when data is an IO' do
+      it 'is an array of all column names' do
+        expect(table.column_names).to eq column_names
+      end
+    end
+
+    describe 'when data is a StringIO' do
+      let(:data) { StringIO.new File.read(dbf_path) }
+      let(:table) { DBF::Table.new data, nil, Encoding::US_ASCII }
+
+      it 'is an array of all column names' do
+        expect(table.column_names).to eq column_names
+      end
     end
   end
 


### PR DESCRIPTION
`build_columns` may be run before header and second column will skiped because header read 32 bytes