### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/dbf/column_type.rb
+++ b/lib/dbf/column_type.rb
@@ -54,7 +54,7 @@ module DBF
 
     class Boolean < Base
       def type_cast(value)
-        value.strip.match? /^(y|t)$/i
+        value.strip.match?(/^(y|t)$/i)
       end
     end
 

--- a/spec/dbf/column_spec.rb
+++ b/spec/dbf/column_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DBF::Column do
         it 'supports negative Integer' do
           value = '-135'
           column = DBF::Column.new table, 'ColumnName', 'N', 3, 0
-          expect(column.type_cast(value)).to eq -135
+          expect(column.type_cast(value)).to eq(-135)
         end
       end
 
@@ -83,7 +83,7 @@ RSpec.describe DBF::Column do
         it 'casts negative value to Float' do
           value = '-13.5'
           column = DBF::Column.new table, 'ColumnName', 'N', 2, 1
-          expect(column.type_cast(value)).to eq -13.5
+          expect(column.type_cast(value)).to eq(-13.5)
         end
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe DBF::Column do
       it 'casts negative value to Float' do
         value = '-135'
         column = DBF::Column.new table, 'ColumnName', 'F', 3, 0
-        expect(column.type_cast(value)).to eq -135.0
+        expect(column.type_cast(value)).to eq(-135.0)
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe DBF::Column do
         it 'supports negative binary' do
           column = DBF::Column.new table, 'ColumnName', 'B', 1, 2
           expect(column.type_cast("\x00\x00\x00\x00\x00\xC0\x65\xC0")).to be_a(Float)
-          expect(column.type_cast("\x00\x00\x00\x00\x00\xC0\x65\xC0")).to eq -174.0
+          expect(column.type_cast("\x00\x00\x00\x00\x00\xC0\x65\xC0")).to eq(-174.0)
         end
       end
     end
@@ -148,7 +148,7 @@ RSpec.describe DBF::Column do
       it 'supports negative Integer' do
         value = "\x24\xE1\xFF\xFF"
         column = DBF::Column.new table, 'ColumnName', 'I', 3, 0
-        expect(column.type_cast(value)).to eq -7900
+        expect(column.type_cast(value)).to eq(-7900)
       end
     end
 
@@ -269,11 +269,11 @@ RSpec.describe DBF::Column do
     end
 
     it 'supports negative currency' do
-      expect(column.type_cast("\xFC\xF0\xF0\xFE\xFF\xFF\xFF\xFF")).to eq -1776.41
+      expect(column.type_cast("\xFC\xF0\xF0\xFE\xFF\xFF\xFF\xFF")).to eq(-1776.41)
     end
 
     it 'supports 64bit negative currency' do
-      expect(column.type_cast("pN'9\xFF\xFF\xFF\xFF")).to eq -333_609.0
+      expect(column.type_cast("pN'9\xFF\xFF\xFF\xFF")).to eq(-333_609.0)
     end
 
     context 'and 0 length' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,6 @@ begin
 rescue LoadError
 end
 
-Encoding.default_external = 'UTF-8'
-
 require 'dbf'
 require 'yaml'
 require 'rspec'


### PR DESCRIPTION
You can see the warnings by running:

`RUBYOPT=-W2 rspec`

Fixes these warnings:

```
warning: ambiguous first argument; put parentheses or a space even after `/' operator
warning: ambiguous first argument; put parentheses or a space even after `-' operator
warning: setting Encoding.default_external
```